### PR TITLE
fix: remove unused unmarked dependency on numpy

### DIFF
--- a/Entities/Maps/Map.py
+++ b/Entities/Maps/Map.py
@@ -3,8 +3,6 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-import numpy as np
-
 import pygame
 
 from Engine.PopupWindow import PopupWindow


### PR DESCRIPTION
At least locally I can't actually run the currently released version (2.2) because I don't (and for reasons I won't get into _can't_) have numpy installed.
The other reasonable approach here would be to add it to `requirements.txt` so that pyinstaller picks it up, if that's more desirable feel free to close this.