### PR TITLE
Two new item types, and some dev features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ templates/twilightprincessmapold.template
 dist___
 default_saves
 .dev
+template_dev/*
+!template_dev/README.md

--- a/Engine/MainMenu.py
+++ b/Engine/MainMenu.py
@@ -67,7 +67,7 @@ class MainMenu:
         self.init_menu()
         self.set_check()
         self.process_templates_list()
-        #self.download_missing_officials_templates()
+        self.download_missing_officials_templates()
         self.loaded_tracker = None
         self.btn_paypal = None
         self.btn_discord = None
@@ -314,15 +314,10 @@ class MainMenu:
         x_title = x_description_menu + 17
         y_title = y_description_menu + 13
 
-        template_title = self.template_list[self.selected_menu_index]["information"]["Informations"]["Name"]
-        template_title_color = self.font_data["color_normal"]
-        if "is_dev" in self.template_list[self.selected_menu_index] and self.template_list[self.selected_menu_index]["is_dev"]:
-            template_title = "DEV TEMPLATE: " + template_title
-            template_title_color = self.font_data["color_error"]
         self.draw_text(
-            text=template_title,
+            text=self.template_list[self.selected_menu_index]["information"]["Informations"]["Name"],
             font_name=self.font_data["path"],
-            color=template_title_color,
+            color=self.font_data["color_normal"],
             font_size=self.font_data["title_size"],
             surface=screen,
             position=(x_title, y_title),
@@ -352,7 +347,18 @@ class MainMenu:
             position=(x_version, y_version),
             outline=1.5)
 
-        if "official" in self.template_list[self.selected_menu_index]:
+        if "is_dev" in self.template_list[self.selected_menu_index] and self.template_list[self.selected_menu_index]["is_dev"]:
+            x_official = x_description_menu + description_menu.get_rect().w - 160
+            y_official = y_description_menu + description_menu.get_rect().h - 35
+            self.draw_text(
+                text="DEV TEMPLATE",
+                font_name=self.font_data["path"],
+                color=self.font_data["color_error"],
+                font_size=self.font_data["size"],
+                surface=screen,
+                position=(x_official, y_official),
+                outline=1.5)
+        elif "official" in self.template_list[self.selected_menu_index]:
             x_official = x_description_menu + description_menu.get_rect().w - 90
             y_official = y_description_menu + description_menu.get_rect().h - 35
             self.draw_text(
@@ -390,6 +396,8 @@ class MainMenu:
                 outline=1.5)
 
     def download_missing_officials_templates(self):
+        if self.core_service.dev_version:
+            return
         for template in self.official_template:
             template_path = os.path.join(self.template_directory, f"{template.get('template_name')}.template")
             if not os.path.exists(template_path):
@@ -457,7 +465,7 @@ class MainMenu:
                     if off_template["template_name"] == template_data["filename"]:
                         template_data["official"] = off_template["lastest_version"]
 
-                        if data[0]["Informations"]["Version"] != template_data["official"]:
+                        if template_data["information"]["Informations"]["Version"] != template_data["official"]:
                             template_data["outdated"] = True
 
                         self.template_list.append(template_data)
@@ -468,6 +476,7 @@ class MainMenu:
 
         for none_official in temp_list:
             self.template_list.append(none_official)
+
         dev_template = self.process_dev_folder()
         if dev_template:
             dev_template["is_dev"] = True
@@ -590,6 +599,8 @@ class MainMenu:
     def keyup(self, button, screen):
         if self.loaded_tracker:
             self.loaded_tracker.keyup(button, screen)
+        elif button == pygame.K_F5:
+            self.process_templates_list()
 
     def events(self, events, time_delta):
         if self.loaded_tracker:

--- a/Engine/Menu.py
+++ b/Engine/Menu.py
@@ -13,8 +13,9 @@ from Tools.SaveLoadTool import SaveLoadTool
 
 
 class Menu:
-    def __init__(self, dimensions, tracker):
+    def __init__(self, dimensions, tracker, is_dev=False):
         self.tracker = tracker
+        self.screen = None
         self.core_service = CoreService()
         self.saveTool = SaveLoadTool()
         font = pygame.font.Font(self.core_service.get_menu_font(), 20)
@@ -49,6 +50,8 @@ class Menu:
         self.menu.add.button('Discord', self.open_discord)
         self.menu.add.button('Pay me a coffee ? :)', self.open_paypal)
         self.menu.add.button('Official website', self.open_website)
+        if is_dev:
+            self.menu.add.button('Take screenshot', self.take_screenshot)
         self.menu.add.button('Close menu', self.menu.disable)
         self.menu.disable()
 
@@ -152,8 +155,16 @@ class Menu:
         self.tracker.back_main_menu()
         self.menu.disable()
 
+    def take_screenshot(self):
+        filename =  os.path.join(self.core_service.get_app_path(), "template_dev", "screenshot.jpg")
+        pygame.image.save(self.screen, filename)
+        self.menu.disable()
+
     def set_tracker(self, tracker):
         self.tracker = tracker
+
+    def set_screen(self, screen):
+        self.screen = screen
 
     @staticmethod
     def open_discord():

--- a/Engine/Tracker.py
+++ b/Engine/Tracker.py
@@ -614,7 +614,8 @@ class Tracker:
                         self.sound_cancel.play()
 
     def items_click(self, item_list, mouse_position, button):
-        for item in item_list:
+        # Reverse the item list order so that the items that seem on top get clicked on
+        for item in reversed(item_list.sprites()):
             # if self.core_service.is_on_element(mouse_positions=mouse_position, element_positons=item.get_position(),
             #                                    element_dimension=(
             #                                    item.get_rect().w, item.get_rect().h)) and self.is_moving is None:

--- a/Engine/Tracker.py
+++ b/Engine/Tracker.py
@@ -704,11 +704,15 @@ class Tracker:
 
         if can_click:
             if self.current_map:
-                self.current_map.click(mouse_position, button)
                 # self.current_map.update()
+                item_was_clicked = False
+                if not self.maps_list_window.is_open() and not self.rules_options_list_window.is_open():
+                    item_was_clicked = self.items_click(self.items, mouse_position, button)
 
-                if not self.maps_list_window.is_open() and not self.rules_options_list_window.is_open() and not self.current_map.check_window.is_open():
-                    self.items_click(self.items, mouse_position, button)
+                if not item_was_clicked:
+                    # We only want to interact with the map if an item wasn't clicked on
+                    # This ensures that we don't close any blocks when interacting with items
+                    self.current_map.click(mouse_position, button)
 
                 if self.maps_list_window.is_open():
                     self.maps_list_window.left_click(mouse_position)

--- a/Engine/Tracker.py
+++ b/Engine/Tracker.py
@@ -405,12 +405,6 @@ class Tracker:
                         item["Sizes"]["h"] * self.core_service.zoom)
 
             def create_base_item(item, item_class, **additional_args):
-                if "PlaceholderIcon" in item:
-                    placeholder_info = item["PlaceholderIcon"]
-                    item_sheet = items_sheet_dict[placeholder_info["SpriteSheet"]]
-                    additional_args["placeholder_icon"] = self.core_service.zoom_image(item_sheet["ImageSheet"].getImageWithRowAndColumn(
-                        row=placeholder_info["row"],
-                        column=placeholder_info["column"]))
                 return item_class(name=item["Name"],
                                   image=item_image,
                                   position=get_position(item),

--- a/Engine/Tracker.py
+++ b/Engine/Tracker.py
@@ -28,6 +28,7 @@ from Entities.Maps.MapNameListItem import MapNameListItem
 from Entities.Maps.RulesOptionsListItem import RulesOptionsListItem
 from Entities.Maps.SimpleCheck import SimpleCheck
 from Entities.MultipleChoiceItem import MultipleChoiceItem
+from Entities.MultipleSelectItem import MultipleSelectItem
 from Entities.SubMenuItem import SubMenuItem
 from Tools.Bank import Bank
 from Tools.CoreService import CoreService
@@ -454,6 +455,7 @@ class Tracker:
                 "AlternateEvolutionItem": AlternateEvolutionItem,
                 "IncrementalItem": IncrementalItem,
                 "MultipleChoiceItem": MultipleChoiceItem,
+                "MultipleSelectItem": MultipleSelectItem,
                 "SubMenuItem": SubMenuItem,
                 "EditableBox": EditableBox,
                 "DraggableEvolutionItem": DraggableEvolutionItem,
@@ -542,6 +544,19 @@ class Tracker:
                                              resources_path=self.resources_path,
                                              tracker=self,
                                              items_list=item["ItemsList"],
+                                             **addlProps)
+
+                elif item["Kind"] == "MultipleSelectItem":
+                    addlProps = {}
+                    if "BackgroundOffset" in item:
+                        addlProps["background_offset"] = get_position(item, "BackgroundOffset")
+
+                    _item = create_base_item(item, item_class,
+                                             background_image=item["Background"],
+                                             resources_path=self.resources_path,
+                                             tracker=self,
+                                             items_list=item["ItemsList"],
+                                             items_sheet_dict=items_sheet_dict,
                                              **addlProps)
 
                 elif item["Kind"] == "SubMenuItem":

--- a/Entities/Item.py
+++ b/Entities/Item.py
@@ -7,8 +7,7 @@ from Tools.CoreService import CoreService
 
 
 class Item(pygame.sprite.Sprite):
-    def __init__(self, id, name, position, image, opacity_disable, hint, enable=True, show_item=True,
-                 placeholder_icon=None):
+    def __init__(self, id, name, position, image, opacity_disable, hint, enable=True, show_item=True):
         pygame.sprite.Sprite.__init__(self)
         self.id = id
         self.show_item = show_item
@@ -22,11 +21,8 @@ class Item(pygame.sprite.Sprite):
         self.base_position = position
         self.core_service = CoreService()
         self.colored_image = image.convert_alpha()
-        if placeholder_icon:
-            self.grey_image = placeholder_icon.convert_alpha()
-        else:
-            self.grey_image = image.convert_alpha()
-            self.core_service.convert_to_gs(self.grey_image)
+        self.grey_image = image.convert_alpha()
+        self.core_service.convert_to_gs(self.grey_image)
         self.left_hint = False
 
         self.hint_items_data = None

--- a/Entities/Item.py
+++ b/Entities/Item.py
@@ -7,7 +7,8 @@ from Tools.CoreService import CoreService
 
 
 class Item(pygame.sprite.Sprite):
-    def __init__(self, id, name, position, image, opacity_disable, hint, enable=True, show_item=True):
+    def __init__(self, id, name, position, image, opacity_disable, hint, enable=True, show_item=True,
+                 placeholder_icon=None):
         pygame.sprite.Sprite.__init__(self)
         self.id = id
         self.show_item = show_item
@@ -21,8 +22,11 @@ class Item(pygame.sprite.Sprite):
         self.base_position = position
         self.core_service = CoreService()
         self.colored_image = image.convert_alpha()
-        self.grey_image = image.convert_alpha()
-        self.core_service.convert_to_gs(self.grey_image)
+        if placeholder_icon:
+            self.grey_image = placeholder_icon.convert_alpha()
+        else:
+            self.grey_image = image.convert_alpha()
+            self.core_service.convert_to_gs(self.grey_image)
         self.left_hint = False
 
         self.hint_items_data = None

--- a/Entities/Maps/Map.py
+++ b/Entities/Maps/Map.py
@@ -3,8 +3,6 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-import numpy as np
-
 import pygame
 
 from Engine.PopupWindow import PopupWindow

--- a/Entities/MultipleChoiceItem.py
+++ b/Entities/MultipleChoiceItem.py
@@ -12,6 +12,8 @@ from Tools.Bank import Bank
 # The main item can then be selected normally, or optionally can automatically select to the chosen item.
 # Middle click will undo all selections.
 #
+# Only really works with Items and labels
+#
 # An example of this would be a bottled item in Majora's Mask, where the contents of the bottle
 # could be easily selected and modified, making it less of a hassle to mark, for example, the seahorse.
 #

--- a/Entities/MultipleChoiceItem.py
+++ b/Entities/MultipleChoiceItem.py
@@ -1,0 +1,159 @@
+import os
+
+import pygame
+import pygame_gui
+
+from Entities.Item import Item
+from Tools.Bank import Bank
+
+# An entity that represents one of a collection of possible items.
+# On right click, will open a submenu with a multiple-choice list of options to pick from
+# and selecting one will set that as the choice for the main item.
+# The main item can then be selected normally, or optionally can automatically select to the chosen item.
+# Middle click will undo all selections.
+#
+# An example of this would be a bottled item in Majora's Mask, where the contents of the bottle
+# could be easily selected and modified, making it less of a hassle to mark, for example, the seahorse.
+#
+# Params:
+#   Background: str - Path to an image to overlay on top of the current tracker, to indicate the change in selection mode.
+#   BackgroundOffset: Position - Offset from the main item's top left corner to place the top left corner of the background.
+#     If omitted, will position background at (0, 0)
+#   ItemsList: Item[] - A list of Item entities to be displayed when the submenu is active.
+#   ActiveOnSelection: bool {Optional} - If the main item should be selected upon selecting a subitem
+#     (as opposed to picking a subitem and manually enabling). Defaults to False.
+#   CloseOnSelection: bool {Optional} - If the submenu should close upon making a selection.
+#     Defaults to False.
+class MultipleChoiceItem(Item):
+    def __init__(self, id, name, image, position, enable, opacity_disable, hint, background_image, resources_path,
+                 tracker, items_list, active_on_selection=False, background_offset=None, close_on_selection=False):
+        self.background_image_name = background_image
+        self.background_image = None
+        self.resources_path = resources_path
+        self.active_on_selection = active_on_selection
+        self.show = False
+        self.items = pygame.sprite.Group()
+        self.manager = pygame_gui.UIManager((pygame.display.get_surface().get_size()))
+        self.bank = Bank()
+        self.tracker = tracker
+        self.items_list = items_list
+        self.close_on_selection = close_on_selection
+        self.background_x = 0
+        self.background_y = 0
+        if background_offset:
+            self.background_x = position[0] + background_offset[0]
+            self.background_y = position[1] + background_offset[1]
+        self.init_items()
+        self.update_background()
+        Item.__init__(self, id=id, name=name, image=image, position=position, enable=enable,
+                      opacity_disable=opacity_disable,
+                      hint=hint)
+
+        self.can_drag = False
+        for item in self.items:
+            item.can_drag = False
+        self.tracker.submenus.add(self)
+
+    def update(self):
+        Item.update(self)
+
+        activeItem = next((item for item in self.items if item.enable), None)
+
+        if activeItem == None:
+            return
+
+        if self.enable or self.active_on_selection:
+            self.image = activeItem.colored_image
+        else:
+            self.image = self.alpha_image(activeItem.grey_image)
+
+        if hasattr(activeItem, "label_list"):
+            font = self.core_service.get_font("labelItemFont")
+            font_path = os.path.join(self.core_service.get_tracker_temp_path(), font["Name"])
+            color_category = "Normal"
+            self.image = self.get_drawing_text(font=font,
+                                           color_category=color_category,
+                                           text=activeItem.label_list[activeItem.label_count],
+                                           font_path=font_path,
+                                           base_image=self.image,
+                                           image_surface=self.image,
+                                           text_position="label",
+                                           offset=activeItem.label_offset)
+
+    def update_background(self):
+        self.background_image = self.bank.addZoomImage(os.path.join(self.resources_path, self.background_image_name))
+
+    def draw_submenu(self, screen, time_delta):
+        if self.show:
+            info_object = pygame.display.Info()
+            s = pygame.Surface((info_object.current_w, info_object.current_h), pygame.SRCALPHA)  # per-pixel alpha
+            s.fill((0, 0, 0, 70))  # notice the alpha value in the color
+            screen.blit(s, (0, 0))
+
+            screen.blit(self.background_image, (self.background_x, self.background_y))
+            self.items.draw(screen)
+
+            self.manager.update(time_delta)
+            self.manager.draw_ui(screen)
+
+    def init_items(self):
+        for item in self.items_list:
+            self.tracker.init_item(item, self.items, self.manager)
+
+    def left_click(self):
+        if self.active_on_selection:
+            # Unselect everything on left click
+            """self.enable = False
+            for item in self.items:
+                item.enable = False
+                item.update()"""
+            # On second thought, it's probably better to just open the menu
+            self.show = not self.show
+        else:
+            self.enable = not self.enable
+        self.update()
+
+    def right_click(self):
+        self.show = not self.show
+
+    def wheel_click(self):
+        # Unselect everything on middle click
+        for item in self.items:
+            item.enable = False
+            item.update()
+        self.update()
+
+    def submenu_click(self, mouse_position, button):
+        if self.show:
+            self.show = self.tracker.items_click(self.items, mouse_position, button)
+            if button == 1 or button == 3:
+                # Only check changes on left/right click
+                theItem = next((item for item in self.items if item.check_click(mouse_position)), None)
+                if theItem != None and theItem.enable:
+                    for item in self.items:
+                        if item != theItem:
+                            item.enable = False
+                            item.update()
+                if self.close_on_selection:
+                    self.show = False
+                self.update()
+
+    def get_data(self):
+        data = Item.get_data(self)
+        items_datas = []
+
+        for item in self.items:
+            items_datas.append(item.get_data())
+
+        data["submenu_items"] = items_datas
+        return data
+
+    def set_data(self, datas):
+        # self.increments_position = datas["increments_position"]
+        for item_datas in datas["submenu_items"]:
+            for item in self.items:
+                if item_datas["name"] == item.name and item_datas["id"] == item.id:
+                    item.set_data(item_datas)
+                    break
+
+        Item.set_data(self, datas)

--- a/Entities/MultipleSelectItem.py
+++ b/Entities/MultipleSelectItem.py
@@ -6,50 +6,46 @@ import pygame_gui
 from Entities.Item import Item
 from Tools.Bank import Bank
 
-# An entity that represents one of a collection of possible items.
-# On right click, will open a submenu with a multiple-choice list of options to pick from
-# and selecting one will set that as the choice for the main item.
-# The main item can then be selected normally, or optionally can automatically select to the chosen item.
-# Middle click will undo all selections.
+# An entity that represents a collection of possible items, all of which are selectable.
+# Left or Right clicking will open a menu that allows selection of some sub-items, and
+# selecting one of these will cause the main item to apply an overlay, so that the
+# different pieces can be joined together.
+# Middle click will deselect all.
 #
-# Only really works with Items and labels
-#
-# An example of this would be a bottled item in Majora's Mask, where the contents of the bottle
-# could be easily selected and modified, making it less of a hassle to mark, for example, the seahorse.
+# An example of this would be boss rewards, which could be presented with a smaller representation
+# (like small medallions arranged in a hexagon for OoT) but with a larger submenu to allow
+# for easier selection of individual items.
 #
 # Params:
 #   Background: str - Path to an image to overlay on top of the current tracker, to indicate the change in selection mode.
 #   BackgroundOffset: Position - Offset from the main item's top left corner to place the top left corner of the background.
 #     If omitted, will position background at (0, 0)
 #   ItemsList: Item[] - A list of Item entities to be displayed when the submenu is active.
-#   ActiveOnSelection: bool {Optional} - If the main item should be selected upon selecting a subitem
-#     (as opposed to picking a subitem and manually enabling). Defaults to False.
-#   CloseOnSelection: bool {Optional} - If the submenu should close upon making a selection.
-#     Defaults to False.
-class MultipleChoiceItem(Item):
+#     Note that Items in the ItemsList should also have a "Representation" object that acts like SheetInformation
+#     Omitting this field will use the item's default sprite, so be sure to use a blank image if you don't want that.
+class MultipleSelectItem(Item):
     def __init__(self, id, name, image, position, enable, opacity_disable, hint, background_image, resources_path,
-                 tracker, items_list, active_on_selection=False, background_offset=None, close_on_selection=False):
+                 tracker, items_list, items_sheet_dict, background_offset=None):
         self.background_image_name = background_image
         self.background_image = None
         self.resources_path = resources_path
-        self.active_on_selection = active_on_selection
         self.show = False
         self.items = pygame.sprite.Group()
         self.manager = pygame_gui.UIManager((pygame.display.get_surface().get_size()))
         self.bank = Bank()
         self.tracker = tracker
         self.items_list = items_list
-        self.close_on_selection = close_on_selection
+        self.items_sheet_dict = items_sheet_dict
         self.background_x = 0
         self.background_y = 0
         if background_offset:
             self.background_x = position[0] + background_offset[0]
             self.background_y = position[1] + background_offset[1]
-        self.init_items()
         self.update_background()
         Item.__init__(self, id=id, name=name, image=image, position=position, enable=enable,
                       opacity_disable=opacity_disable,
                       hint=hint)
+        self.init_items()
 
         self.can_drag = False
         for item in self.items:
@@ -64,23 +60,15 @@ class MultipleChoiceItem(Item):
         if activeItem == None:
             return
 
-        if self.enable or self.active_on_selection:
-            self.image = activeItem.colored_image
-        else:
-            self.image = self.alpha_image(activeItem.grey_image)
+        temp_surface = pygame.Surface([self.position[0], self.position[1]], pygame.SRCALPHA, 32)
+        temp_surface = temp_surface.convert_alpha()
+        temp_surface.blit(self.colored_image, (0, 0))
 
-        if hasattr(activeItem, "label_list"):
-            font = self.core_service.get_font("labelItemFont")
-            font_path = os.path.join(self.core_service.get_tracker_temp_path(), font["Name"])
-            color_category = "Normal"
-            self.image = self.get_drawing_text(font=font,
-                                           color_category=color_category,
-                                           text=activeItem.label_list[activeItem.label_count],
-                                           font_path=font_path,
-                                           base_image=self.image,
-                                           image_surface=self.image,
-                                           text_position="label",
-                                           offset=activeItem.label_offset)
+        for item in self.items:
+            if item.enable and hasattr(item, "representation"):
+                temp_surface.blit(item.representation, (0, 0))
+        self.image = temp_surface
+        return
 
     def update_background(self):
         self.background_image = self.bank.addZoomImage(os.path.join(self.resources_path, self.background_image_name))
@@ -101,18 +89,22 @@ class MultipleChoiceItem(Item):
     def init_items(self):
         for item in self.items_list:
             self.tracker.init_item(item, self.items, self.manager)
+        for i, item in enumerate(self.items):
+            item_data = self.items_list[i]
+            if "Representation" in item_data:
+                item_sheet = self.items_sheet_dict[item_data["Representation"]["SpriteSheet"]]
+                item.representation = self.core_service.zoom_image(
+                    item_sheet["ImageSheet"].getImageWithRowAndColumn(
+                        row=item_data["Representation"]["row"],
+                        column=item_data["Representation"]["column"]
+                    )
+                )
+            else:
+                item.representation = item.colored_image
+
 
     def left_click(self):
-        if self.active_on_selection:
-            # Unselect everything on left click
-            """self.enable = False
-            for item in self.items:
-                item.enable = False
-                item.update()"""
-            # On second thought, it's probably better to just open the menu
-            self.show = not self.show
-        else:
-            self.enable = not self.enable
+        self.show = not self.show
         self.update()
 
     def right_click(self):
@@ -129,17 +121,7 @@ class MultipleChoiceItem(Item):
     def submenu_click(self, mouse_position, button):
         if self.show:
             self.show = self.tracker.items_click(self.items, mouse_position, button)
-            if button == 1 or button == 3:
-                # Only check changes on left/right click
-                theItem = next((item for item in self.items if item.check_click(mouse_position)), None)
-                if theItem != None and theItem.enable:
-                    for item in self.items:
-                        if item != theItem:
-                            item.enable = False
-                            item.update()
-                if self.close_on_selection:
-                    self.show = False
-                self.update()
+            self.update()
 
     def get_data(self):
         data = Item.get_data(self)

--- a/Entities/MultipleSelectItem.py
+++ b/Entities/MultipleSelectItem.py
@@ -89,8 +89,7 @@ class MultipleSelectItem(Item):
     def init_items(self):
         for item in self.items_list:
             self.tracker.init_item(item, self.items, self.manager)
-        for i, item in enumerate(self.items):
-            item_data = self.items_list[i]
+        for item_data, item in zip(self.items_list, self.items):
             if "Representation" in item_data:
                 item_sheet = self.items_sheet_dict[item_data["Representation"]["SpriteSheet"]]
                 item.representation = self.core_service.zoom_image(

--- a/Entities/SubMenuItem.py
+++ b/Entities/SubMenuItem.py
@@ -114,5 +114,3 @@ class SubMenuItem(Item):
                     break
 
         Item.set_data(self, datas)
-
-

--- a/Tools/TemplateChecker.py
+++ b/Tools/TemplateChecker.py
@@ -291,6 +291,8 @@ class TemplateChecker:
                     self.__check_go_mode_item(item, i)
                 elif item["Kind"] == "Item":
                     pass
+                elif item["Kind"] == "MultipleChoiceItem":
+                    pass
                 elif item["Kind"] == "SubMenuItem":
                     pass
                 elif item["Kind"] == "AlternateEvolutionItem":

--- a/Tools/TemplateChecker.py
+++ b/Tools/TemplateChecker.py
@@ -293,6 +293,8 @@ class TemplateChecker:
                     pass
                 elif item["Kind"] == "MultipleChoiceItem":
                     pass
+                elif item["Kind"] == "MultipleSelectItem":
+                    pass
                 elif item["Kind"] == "SubMenuItem":
                     pass
                 elif item["Kind"] == "AlternateEvolutionItem":

--- a/template_dev/README.md
+++ b/template_dev/README.md
@@ -1,0 +1,1 @@
+This is a folder that allows for development work on templates without having to rezip each time you want to make a change


### PR DESCRIPTION
## Changes
- Added **MultipleChoiceItem** entity, which opens a submenu for additional items
  - If ActiveOnSelection is true, clicking one of these items will close the submenu and set the main icon to be active, using the icon of the selected item. This pretty much acts as a faster version of an Evolution Item.
  - If ActiveOnSelection is false, clicking on one of these items will set the main icon to the selected item, but won't be active unless manually toggled. This can be used, for example, to updated items in Bottles, or easily pick dungeon rewards if you know where a reward is, but haven't yet obtained it.
  - Middle clicking will deselect all for both modes.
  - Selecting one item in the submenu will automatically deselect all other items.
- Added **MultipleSelectItem** entity, which similarly opens a submenu for additional items
  - MultipleSelectItem allows subitems to have a "Representation" which is an image that will overlay the main icon.
  - An example of this is for dungeon rewards if you want a smaller representation of all the rewards but don't want the click targets to actually be that small
  - Honestly, I don't know if there are too many valuable use cases for this one, but I felt like I should do it to pair with MultipleChoiceItem
- Reversed item order when clicking, since items later in the list will be drawn on top so it's more intuitive that they receive the clicks.
  - I'm not super attached to this change, but it feels a bit better to me. If going through a reversed list is worse than going through it normally, I'm fine with removing this.
- Removed unused numpy dependency
- Modified map blocks such that interacting with any items in the tracker won't close the current check window. The only potential weird behavior I can see with this is if a template dev puts an item "out of bounds" on the map screen, which doesn't feel like a particularly supported feature.
- Added a lot of features for template developers:
  - Pressing F5 on the main menu will reload the templates list, preventing the need to close + reopen the application. I don't think replacing assets works with this, but modifications to the tracker json will be read.
  - Added new folder `template_dev`, which acts like a normal template without requiring the dev to rezip+rename each time they want to make a change
  - When viewing the template in `template_dev`, added a menu option to take a simple screenshot of the tracker for previews. I don't think things like submenus will render to the screenshot, but it should record all Entities in their proper states.

![2024-07-22 09-10-51](https://github.com/user-attachments/assets/6f185c18-9653-4eab-a8ad-262c1599fe01)

## Testing
Played pretty extensively with the new Entities. Checked my own and official templates to confirm no regressions were introduced.

## Other Notes
I'm not a python dev and haven't really worked with python in like 7 years. If my patterns seem like js + React that's because that's what I do.